### PR TITLE
Initial AD5X Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "test:watch": "jest --watch",
     "test:legacy": "tsx src/test.ts"
   },
-  "keywords": ["flashforge", "3d-printer", "api"],
+  "keywords": [
+    "flashforge",
+    "3d-printer",
+    "api"
+  ],
   "author": "GhostTypes",
   "license": "ISC",
   "devDependencies": {
@@ -23,8 +27,8 @@
     "@types/node": "^22.14.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.8.3",
-    "tsx": "^4.0.0"
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "axios": "^1.8.4",
@@ -40,11 +44,16 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "testMatch": ["**/*.test.ts"],
+    "testMatch": [
+      "**/*.test.ts"
+    ],
     "transform": {
-      "^.+\\.ts$": ["ts-jest", {
-        "diagnostics": false
-      }]
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
     }
   }
 }

--- a/src/api/PrinterDiscovery.ts
+++ b/src/api/PrinterDiscovery.ts
@@ -13,13 +13,19 @@ export class FlashForgePrinter {
     public serialNumber: string = '';
     /** The IP address of the printer. */
     public ipAddress: string = '';
+    /** Optional flag indicating if the discovered printer is an AD5X model, based on its name. */
+    public isAD5X?: boolean;
 
     /**
      * Returns a string representation of the FlashForgePrinter object.
-     * @returns A string containing the printer's name, serial number, and IP address.
+     * @returns A string containing the printer's name, serial number, IP address, and AD5X status if applicable.
      */
     public toString(): string {
-        return `Name: ${this.name}, Serial: ${this.serialNumber}, IP: ${this.ipAddress}`;
+        let str = `Name: ${this.name}, Serial: ${this.serialNumber}, IP: ${this.ipAddress}`;
+        if (this.isAD5X) {
+            str += ", Model: AD5X";
+        }
+        return str;
     }
 }
 
@@ -200,6 +206,9 @@ export class FlashForgePrinterDiscovery {
         printer.name = name;
         printer.serialNumber = serialNumber;
         printer.ipAddress = ipAddress;
+        if (name === "AD5X") {
+            printer.isAD5X = true;
+        }
 
         return printer;
     }

--- a/src/api/controls/Files.test.ts
+++ b/src/api/controls/Files.test.ts
@@ -1,0 +1,152 @@
+import axios from 'axios';
+import { FiveMClient } from '../../FiveMClient';
+import { Files } from './Files';
+import { Endpoints } from '../server/Endpoints';
+import { FFGcodeFileEntry, FFGcodeToolData } from '../../models/ff-models';
+import { NetworkUtils } from '../network/NetworkUtils';
+
+// Mock FiveMClient and its dependencies as needed
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock NetworkUtils.isOk
+jest.mock('../network/NetworkUtils', () => ({
+    NetworkUtils: {
+        isOk: jest.fn(),
+    },
+}));
+const mockedNetworkUtils = NetworkUtils as jest.Mocked<typeof NetworkUtils>;
+
+
+describe('Files Control', () => {
+    let mockFiveMClient: FiveMClient;
+    let filesControl: Files;
+
+    beforeEach(() => {
+        // Reset mocks before each test
+        mockedAxios.post.mockReset();
+        mockedNetworkUtils.isOk.mockReset();
+
+        // Setup default mock behavior
+        mockedNetworkUtils.isOk.mockImplementation((response: any) => response && response.code === 0);
+
+
+        // A very basic mock for FiveMClient, only providing what Files control needs
+        mockFiveMClient = {
+            getEndpoint: (endpoint: string) => `http://fakeprinter:8898${endpoint}`,
+            serialNumber: 'testSN',
+            checkCode: 'testCC',
+        } as FiveMClient; // Cast to FiveMClient, add more properties if Files uses them
+
+        filesControl = new Files(mockFiveMClient);
+    });
+
+    describe('getRecentFileList', () => {
+        const ad5xGcodeListResponse: FFGcodeFileEntry[] = [
+            {
+                "gcodeFileName": "FISH_PLA.3mf",
+                "gcodeToolCnt": 4,
+                "gcodeToolDatas": [
+                    { "filamentWeight": 3.28, "materialColor": "#FFFF00", "materialName": "PLA", "slotId": 0, "toolId": 0 },
+                    { "filamentWeight": 0.51, "materialColor": "#FFFF00", "materialName": "PLA", "slotId": 0, "toolId": 1 },
+                    { "filamentWeight": 18.10, "materialColor": "#FF0000", "materialName": "PLA", "slotId": 0, "toolId": 2 },
+                    { "filamentWeight": 6.15, "materialColor": "#FF8040", "materialName": "PLA", "slotId": 0, "toolId": 3 }
+                ],
+                "printingTime": 29958,
+                "totalFilamentWeight": 28.04,
+                "useMatlStation": true
+            },
+            {
+                "gcodeFileName": "FlashForge-TestModel-01.3mf",
+                "gcodeToolCnt": 2,
+                "gcodeToolDatas": [
+                    { "filamentWeight": 3.46, "materialColor": "#FFFFFF", "materialName": "PLA", "slotId": 0, "toolId": 0 },
+                    { "filamentWeight": 0.26, "materialColor": "#0000FF", "materialName": "PLA", "slotId": 0, "toolId": 1 }
+                ],
+                "printingTime": 849,
+                "totalFilamentWeight": 3.73,
+                "useMatlStation": true
+            }
+        ];
+
+        const olderPrinterGcodeListResponse: string[] = [
+            "test_file1.gcode",
+            "another_print.gcode"
+        ];
+
+        it('should correctly parse AD5X-style detailed G-code list', async () => {
+            mockedAxios.post.mockResolvedValue({
+                status: 200,
+                data: { code: 0, message: 'Success', gcodeList: ad5xGcodeListResponse }
+            });
+            mockedNetworkUtils.isOk.mockReturnValue(true);
+
+            const result = await filesControl.getRecentFileList();
+
+            expect(result).toHaveLength(2);
+            expect(result[0].gcodeFileName).toBe("FISH_PLA.3mf");
+            expect(result[0].gcodeToolCnt).toBe(4);
+            expect(result[0].gcodeToolDatas).toHaveLength(4);
+            expect(result[0].gcodeToolDatas?.[2].materialColor).toBe("#FF0000");
+            expect(result[0].totalFilamentWeight).toBe(28.04);
+            expect(result[0].useMatlStation).toBe(true);
+            expect(result[1].gcodeFileName).toBe("FlashForge-TestModel-01.3mf");
+        });
+
+        it('should correctly parse older printer string-array G-code list', async () => {
+            mockedAxios.post.mockResolvedValue({
+                status: 200,
+                data: { code: 0, message: 'Success', gcodeList: olderPrinterGcodeListResponse }
+            });
+            mockedNetworkUtils.isOk.mockReturnValue(true);
+
+            const result = await filesControl.getRecentFileList();
+
+            expect(result).toHaveLength(2);
+            expect(result[0].gcodeFileName).toBe("test_file1.gcode");
+            expect(result[0].printingTime).toBe(0); // Defaulted
+            expect(result[0].gcodeToolDatas).toBeUndefined();
+            expect(result[1].gcodeFileName).toBe("another_print.gcode");
+        });
+
+        it('should return an empty array for an empty G-code list', async () => {
+            mockedAxios.post.mockResolvedValue({
+                status: 200,
+                data: { code: 0, message: 'Success', gcodeList: [] }
+            });
+            mockedNetworkUtils.isOk.mockReturnValue(true);
+
+            const result = await filesControl.getRecentFileList();
+            expect(result).toHaveLength(0);
+        });
+
+        it('should return an empty array if API response is not OK', async () => {
+            mockedAxios.post.mockResolvedValue({
+                status: 200,
+                data: { code: 1, message: 'Error from printer', gcodeList: [] }
+            });
+            mockedNetworkUtils.isOk.mockReturnValue(false); // Simulate NetworkUtils.isOk returning false
+
+            const result = await filesControl.getRecentFileList();
+            expect(result).toHaveLength(0);
+        });
+
+        it('should return an empty array if HTTP status is not 200', async () => {
+            mockedAxios.post.mockResolvedValue({
+                status: 500,
+                data: {} // Data doesn't matter here
+            });
+            // NetworkUtils.isOk won't even be called if status is not 200
+
+            const result = await filesControl.getRecentFileList();
+            expect(result).toHaveLength(0);
+        });
+
+        it('should return an empty array on axios POST error', async () => {
+            mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+
+            const result = await filesControl.getRecentFileList();
+            expect(result).toHaveLength(0);
+        });
+    });
+});

--- a/src/models/MachineInfo.test.ts
+++ b/src/models/MachineInfo.test.ts
@@ -1,0 +1,214 @@
+import { MachineInfo } from './MachineInfo';
+import { FFPrinterDetail, MachineState, SlotInfo, MatlStationInfo, IndepMatlInfo } from './ff-models';
+
+const AD5X_PRINTER_DETAIL_JSON: FFPrinterDetail = {
+  "autoShutdown": "close",
+  "autoShutdownTime": 30,
+  "cameraStreamUrl": "",
+  "chamberFanSpeed": 0,
+  "chamberTargetTemp": 0,
+  "chamberTemp": 0,
+  "clearFanStatus": "open", // This field was in the example but not in FFPrinterDetail, assuming it's not standard or a typo. Will omit.
+  "coolingFanLeftSpeed": 0,
+  "coolingFanSpeed": 0,
+  "cumulativeFilament": 0.0,
+  "cumulativePrintTime": 0,
+  "currentPrintSpeed": 0,
+  "doorStatus": "close",
+  "errorCode": "",
+  "estimatedLeftLen": 0, // For AD5X with material station, these might behave differently or be less relevant
+  "estimatedLeftWeight": 0.0,
+  "estimatedRightLen": 0, // For AD5X, this might represent the active extruder from station
+  "estimatedRightWeight": 0.0,
+  "estimatedTime": 0.0,
+  "externalFanStatus": "close",
+  "fillAmount": 0,
+  "firmwareVersion": "1.1.3-1.0.8",
+  "flashRegisterCode": "",
+  "hasLeftFilament": false, // Could be true if direct extruder also used
+  "hasMatlStation": true,
+  "hasRightFilament": false, // Could be true if direct extruder also used
+  "indepMatlInfo": {
+    "materialColor": "",
+    "materialName": "?",
+    "stateAction": 0,
+    "stateStep": 0
+  },
+  "internalFanStatus": "close",
+  "ipAddr": "192.168.0.204",
+  "leftFilamentType": "", // Might be populated by indepMatlInfo or active station slot
+  "leftTargetTemp": 0,
+  "leftTemp": 0,
+  "lightStatus": "open",
+  "location": "Group A",
+  "macAddr": "88:A9:A7:9D:2A:70",
+  "matlStationInfo": {
+    "currentLoadSlot": 0,
+    "currentSlot": 0,
+    "slotCnt": 4,
+    "slotInfos": [
+      {
+        "hasFilament": true,
+        "materialColor": "#FFFFFF",
+        "materialName": "PLA",
+        "slotId": 1
+      },
+      {
+        "hasFilament": true,
+        "materialColor": "#2750E0",
+        "materialName": "PLA",
+        "slotId": 2
+      },
+      {
+        "hasFilament": true,
+        "materialColor": "#FEF043",
+        "materialName": "PLA",
+        "slotId": 3
+      },
+      {
+        "hasFilament": true,
+        "materialColor": "#F95D73",
+        "materialName": "PLA",
+        "slotId": 4
+      }
+    ],
+    "stateAction": 0,
+    "stateStep": 0
+  },
+  "measure": "220X220X220",
+  "name": "AD5X",
+  "nozzleCnt": 1,
+  "nozzleModel": "0.4mm",
+  "nozzleStyle": 0,
+  "pid": 38,
+  "platTargetTemp": 0.0,
+  "platTemp": 27.75,
+  "polarRegisterCode": ""
+  // "status", "printDuration", "printFileName" etc. are missing but MachineInfo.fromDetail handles defaults
+};
+
+// Basic mock for a non-AD5X printer (e.g., 5M)
+const GENERIC_PRINTER_DETAIL_JSON: FFPrinterDetail = {
+    "name": "FlashForge 5M",
+    "firmwareVersion": "1.0.0",
+    "ipAddr": "192.168.1.100",
+    "macAddr": "AA:BB:CC:DD:EE:FF",
+    "coolingFanSpeed": 100,
+    "platTemp": 60.5,
+    "platTargetTemp": 60.0,
+    "rightTemp": 210.3,
+    "rightTargetTemp": 210.0,
+    "status": "ready",
+    "cumulativePrintTime": 1200, // 20 hours in minutes
+    "cumulativeFilament": 500.75, // meters
+    // No AD5X specific fields
+};
+
+
+describe('MachineInfo', () => {
+  describe('fromDetail', () => {
+    const machineInfoConverter = new MachineInfo();
+
+    it('should correctly parse AD5X printer details', () => {
+      const result = machineInfoConverter.fromDetail(AD5X_PRINTER_DETAIL_JSON);
+
+      expect(result).not.toBeNull();
+      if (!result) return; // Type guard
+
+      expect(result.Name).toBe("AD5X");
+      expect(result.IsAD5X).toBe(true);
+      expect(result.IsPro).toBe(false); // As per our logic Name=AD5X implies IsPro=false
+      expect(result.FirmwareVersion).toBe("1.1.3-1.0.8");
+
+      expect(result.HasMatlStation).toBe(true);
+      expect(result.CoolingFanLeftSpeed).toBe(0);
+      expect(result.CoolingFanSpeed).toBe(0);
+
+      // Check MatlStationInfo
+      expect(result.MatlStationInfo).toBeDefined();
+      const matlStation = result.MatlStationInfo as MatlStationInfo; // Type assertion for easier access
+      expect(matlStation.currentLoadSlot).toBe(0);
+      expect(matlStation.currentSlot).toBe(0);
+      expect(matlStation.slotCnt).toBe(4);
+      expect(matlStation.slotInfos).toHaveLength(4);
+      expect(matlStation.slotInfos[0].materialName).toBe("PLA");
+      expect(matlStation.slotInfos[0].slotId).toBe(1);
+      expect(matlStation.slotInfos[1].materialColor).toBe("#2750E0");
+      expect(matlStation.slotInfos[1].slotId).toBe(2);
+
+      // Check IndepMatlInfo
+      expect(result.IndepMatlInfo).toBeDefined();
+      const indepMatl = result.IndepMatlInfo as IndepMatlInfo; // Type assertion
+      expect(indepMatl.materialName).toBe("?");
+      expect(indepMatl.stateAction).toBe(0);
+
+      // Check some standard fields too
+      expect(result.IpAddress).toBe("192.168.0.204");
+      expect(result.MacAddress).toBe("88:A9:A7:9D:2A:70");
+      expect(result.PrintBed.current).toBe(27.75);
+      expect(result.Extruder.current).toBe(0); // Assuming rightTemp is for the active extruder
+      expect(result.MachineState).toBe(MachineState.Unknown); // status was not in AD5X JSON, so defaults to Unknown
+    });
+
+    it('should correctly parse generic (non-AD5X) printer details', () => {
+      const result = machineInfoConverter.fromDetail(GENERIC_PRINTER_DETAIL_JSON);
+
+      expect(result).not.toBeNull();
+      if (!result) return; // Type guard
+
+      expect(result.Name).toBe("FlashForge 5M");
+      expect(result.IsAD5X).toBe(false);
+      expect(result.IsPro).toBe(false); // "FlashForge 5M" does not contain "Pro"
+      expect(result.FirmwareVersion).toBe("1.0.0");
+
+      expect(result.HasMatlStation).toBeUndefined();
+      expect(result.MatlStationInfo).toBeUndefined();
+      expect(result.IndepMatlInfo).toBeUndefined();
+      expect(result.CoolingFanLeftSpeed).toBeUndefined();
+
+      expect(result.CoolingFanSpeed).toBe(100);
+      expect(result.IpAddress).toBe("192.168.1.100");
+      expect(result.PrintBed.current).toBe(60.5);
+      expect(result.Extruder.current).toBe(210.3);
+      expect(result.MachineState).toBe(MachineState.Ready);
+      expect(result.FormattedTotalRunTime).toBe("20h:0m"); // 1200 minutes
+    });
+
+    it('should correctly identify a non-AD5X Pro model', () => {
+        const proPrinterDetail: FFPrinterDetail = {
+            ...GENERIC_PRINTER_DETAIL_JSON,
+            name: "FlashForge 5M Pro",
+        };
+        const result = machineInfoConverter.fromDetail(proPrinterDetail);
+        expect(result).not.toBeNull();
+        if (!result) return;
+
+        expect(result.Name).toBe("FlashForge 5M Pro");
+        expect(result.IsAD5X).toBe(false);
+        expect(result.IsPro).toBe(true);
+    });
+
+    it('should return null if detail is null', () => {
+      const result = machineInfoConverter.fromDetail(null);
+      expect(result).toBeNull();
+    });
+
+    // Test for default values if some fields are missing in FFPrinterDetail
+    it('should handle missing optional fields gracefully with defaults', () => {
+        const minimalDetail: FFPrinterDetail = { name: "Minimal" };
+        const result = machineInfoConverter.fromDetail(minimalDetail);
+
+        expect(result).not.toBeNull();
+        if (!result) return;
+
+        expect(result.Name).toBe("Minimal");
+        expect(result.IsAD5X).toBe(false);
+        expect(result.IsPro).toBe(false);
+        expect(result.FirmwareVersion).toBe(""); // Defaults to empty string
+        expect(result.CoolingFanSpeed).toBe(0); // Defaults to 0
+        expect(result.PrintBed.current).toBe(0);
+        expect(result.Extruder.set).toBe(0);
+        expect(result.MachineState).toBe(MachineState.Unknown); // status is empty
+    });
+  });
+});

--- a/src/models/MachineInfo.ts
+++ b/src/models/MachineInfo.ts
@@ -1,5 +1,5 @@
 // src/api/models/MachineInfo.ts
-import {FFMachineInfo, FFPrinterDetail, MachineState} from './ff-models';
+import {FFMachineInfo, FFPrinterDetail, MachineState, MatlStationInfo, IndepMatlInfo} from './ff-models';
 
 /**
  * Transforms printer detail data from the API response format into a structured `FFMachineInfo` object.
@@ -57,6 +57,7 @@ export class MachineInfo {
                 // Fan speeds
                 ChamberFanSpeed: detail.chamberFanSpeed || 0,
                 CoolingFanSpeed: detail.coolingFanSpeed || 0,
+                CoolingFanLeftSpeed: detail.coolingFanLeftSpeed, // Keep as undefined if not present
 
                 // Cumulative stats
                 CumulativeFilament: detail.cumulativeFilament || 0,
@@ -90,8 +91,14 @@ export class MachineInfo {
                 FillAmount: detail.fillAmount || 0,
                 FirmwareVersion: detail.firmwareVersion || '',
                 Name: detail.name || '',
-                IsPro: (detail.name || '').includes("Pro"),
+                IsPro: (detail.name || '').includes("Pro") && detail.name !== "AD5X", // AD5X is special
+                IsAD5X: detail.name === "AD5X",
                 NozzleSize: detail.nozzleModel || '',
+
+                // Material Station Info
+                HasMatlStation: detail.hasMatlStation,
+                MatlStationInfo: detail.matlStationInfo, // Assign directly
+                IndepMatlInfo: detail.indepMatlInfo, // Assign directly
 
                 // Temperatures
                 PrintBed: {

--- a/src/test.ts
+++ b/src/test.ts
@@ -86,9 +86,9 @@ async function testRecentFiles(client: FiveMClient) {
 
 async function runTest() {
     // Replace these values with your actual printer information
-    const ipAddress = '192.168.0.202'; // Replace with your printer's IP
-    const serialNumber = 'SNMOMC9900728'; // Replace with your printer's serial number
-    const checkCode = 'e5c2bf77'; // Replace with your printer's check code
+    const ipAddress = '192.168.0.204'; // Replace with your printer's IP
+    const serialNumber = 'SNMQRE9400951'; // Replace with your printer's serial number
+    const checkCode = '0e35a229'; // Replace with your printer's check code
 
     console.log('=== FlashForge API Test ===');
     console.log(`Attempting to connect to printer at ${ipAddress}`);

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,6 +1,6 @@
 // src/test.ts
 import { FiveMClient } from './index';
-import { FlashForgePrinterDiscovery, FlashForgePrinter, MachineState } from './index';
+import { FlashForgePrinterDiscovery, FlashForgePrinter, MachineState, FFGcodeFileEntry, FFGcodeToolData } from './index';
 
 
 function failTest(reason: string) {
@@ -40,6 +40,49 @@ runTest().catch(error => {
     console.error('Unhandled error in test:', error);
 });
 
+async function testRecentFiles(client: FiveMClient) {
+    console.log('\n=== Testing Recent File List (getRecentFileList) ===');
+    try {
+        const recentFiles = await client.files.getRecentFileList();
+        if (recentFiles && recentFiles.length > 0) {
+            console.log(`Retrieved ${recentFiles.length} recent files:`);
+            recentFiles.forEach((file: FFGcodeFileEntry, index: number) => {
+                console.log(`\nFile #${index + 1}:`);
+                console.log(`  Name: ${file.gcodeFileName}`);
+                console.log(`  Printing Time: ${file.printingTime}s`);
+                if (file.totalFilamentWeight !== undefined) {
+                    console.log(`  Total Filament Weight: ${file.totalFilamentWeight.toFixed(2)}g`);
+                }
+                if (file.useMatlStation !== undefined) {
+                    console.log(`  Uses Material Station: ${file.useMatlStation}`);
+                }
+                if (file.gcodeToolCnt !== undefined) {
+                    console.log(`  Tool Count: ${file.gcodeToolCnt}`);
+                }
+                if (file.gcodeToolDatas && file.gcodeToolDatas.length > 0) {
+                    console.log('  Tool Data:');
+                    file.gcodeToolDatas.forEach((toolData: FFGcodeToolData, toolIndex: number) => {
+                        console.log(`    Tool ${toolData.toolId}:`);
+                        console.log(`      Material: ${toolData.materialName} (${toolData.materialColor})`);
+                        console.log(`      Filament Weight: ${toolData.filamentWeight.toFixed(2)}g`);
+                        if (toolData.slotId !== undefined && toolData.slotId !== 0) {
+                             console.log(`      Slot ID: ${toolData.slotId}`);
+                        }
+                    });
+                } else if (typeof file === 'object' && !file.gcodeToolDatas && client.isAD5X) {
+                    // If it's an AD5X and we expected tool data but didn't get it (for an object entry)
+                    console.log('  Note: AD5X printer, but no detailed gcodeToolDatas found for this file. It might be an older file format or a non-multi-material print.');
+                }
+            });
+        } else if (recentFiles) {
+            console.log('No recent files found on the printer.');
+        } else {
+            console.error('Failed to retrieve recent files list (returned null/undefined).');
+        }
+    } catch (error) {
+        console.error('Error during testRecentFiles:', error);
+    }
+}
 
 async function runTest() {
     // Replace these values with your actual printer information
@@ -82,6 +125,42 @@ async function runTest() {
             console.log(`- Current State: ${MachineState[info.MachineState]}`);
             console.log(`- Hot End Temperature: ${info.Extruder.current}°C`);
             console.log(`- Bed Temperature: ${info.PrintBed.current}°C`);
+            console.log(`- Is AD5X: ${client.isAD5X}`); // Log if client identifies it as AD5X
+            console.log(`- Is Pro: ${client.isPro}`);
+
+
+            if (client.isAD5X && info.HasMatlStation) {
+                console.log('\n=== AD5X Material Station Info (/detail) ===');
+                if (info.MatlStationInfo) {
+                    const msInfo = info.MatlStationInfo;
+                    console.log('Material Station Details:');
+                    console.log(`  Current Load Slot: ${msInfo.currentLoadSlot}`);
+                    console.log(`  Current Active Slot: ${msInfo.currentSlot}`);
+                    console.log(`  Total Slots: ${msInfo.slotCnt}`);
+                    if (msInfo.slotInfos && msInfo.slotInfos.length > 0) {
+                        console.log('  Slot Information:');
+                        msInfo.slotInfos.forEach(slot => {
+                            console.log(`    Slot ID: ${slot.slotId}`);
+                            console.log(`      Has Filament: ${slot.hasFilament}`);
+                            console.log(`      Material: ${slot.materialName} (${slot.materialColor})`);
+                        });
+                    } else {
+                        console.log('  No detailed slot information available.');
+                    }
+                } else {
+                    console.log('  Material Station Info not fully available in /detail response.');
+                }
+
+                if (info.IndepMatlInfo) {
+                    const imInfo = info.IndepMatlInfo;
+                    console.log('Independent Material Info:');
+                    console.log(`  Material: ${imInfo.materialName} (${imInfo.materialColor})`);
+                    console.log(`  State Action: ${imInfo.stateAction}, State Step: ${imInfo.stateStep}`);
+                } else {
+                     console.log('  Independent Material Info not available in /detail response.');
+                }
+            }
+
 
             if (info.Status === 'printing') {
                 console.log('\nPrinter is printing:');
@@ -95,6 +174,9 @@ async function runTest() {
             let files = await client.files.getLocalFileList()
             if (files.length < 1) failTest("No local files found, ensure the printer has at least one local file for proper testing.")
             console.log('Local file(s) count: ' + files.length);
+
+            // Test recent files list (especially for AD5X)
+            await testRecentFiles(client);
 
         } else {
             console.error('Failed to get printer information!');


### PR DESCRIPTION
## Summary
This commit adds initial support for AD5X printers, tested on firmware ```1.1.3-1.0.8```. More work is needed to properly support the new /gcodeList response format

## Changes
- Create FFGcodeFileEntry and add FFGcodeToolData models for detailed G-code list entries from AD5X.
- Modify Files.getRecentFileList to parse both new object-based and older string-based /gcodeList responses, returning FFGcodeFileEntry[]
- Update FFPrinterDetail and FFMachineInfo models to include AD5X-specific fields such as material station info (hasMatlStation, matlStationInfo, indepMatlInfo) and left cooling fan speed.

## General Info 
![image](https://github.com/user-attachments/assets/716d5a44-5095-42d3-9fe2-e6278d68329d)
## Material Station Info
![image](https://github.com/user-attachments/assets/a9fec1cc-cfad-44a6-85f6-659a2530936a)
## Print Progress
![image](https://github.com/user-attachments/assets/c603dc10-fc9f-413b-9abc-6f238681fafd)
